### PR TITLE
fix 1.17.1 memory leak

### DIFF
--- a/src/main/java/me/voidxwalker/worldpreview/mixin/client/render/chunk/ChunkBuilderMixin.java
+++ b/src/main/java/me/voidxwalker/worldpreview/mixin/client/render/chunk/ChunkBuilderMixin.java
@@ -33,24 +33,7 @@ public class ChunkBuilderMixin {
     @Inject(method = "<init>", at = @At(value = "TAIL"))
     public void worldpreview_sodiumCompatibility(World world, WorldRenderer worldRenderer, Executor executor, boolean is64Bits, BlockBufferBuilderStorage buffers, CallbackInfo ci) {
         if(MinecraftClient.getInstance().currentScreen instanceof LevelLoadingScreen) {
-            int i = Math.max(1, (int) ((double) Runtime.getRuntime().maxMemory() * 0.3D) / (RenderLayer.getBlockLayers().stream().mapToInt(RenderLayer::getExpectedBufferSize).sum() * 4) - 1);
-            int j = Runtime.getRuntime().availableProcessors();
-            int k = is64Bits ? j : Math.min(j, 4);
-            int l = Math.max(1, Math.min(k, i));
-            ArrayList list = this.worldpreview_getList(l);
-            try {
-                for (int m = 0; m < l; ++m) {
-                    list.add(new BlockBufferBuilderStorage());
-                }
-            } catch (OutOfMemoryError var14) {
-                LOGGER.warn("Allocated only {}/{} buffers", list.size(), l);
-                int n = Math.min(list.size() * 2 / 3, list.size() - 1);
-
-                for (int o = 0; o < n; ++o) {
-                    list.remove(list.size() - 1);
-                }
-                System.gc();
-            }
+            ArrayList list = this.worldpreview_getList(0);
 
             this.threadBuffers = Queues.newArrayDeque(list);
             this.bufferCount = this.threadBuffers.size();


### PR DESCRIPTION
not the best solution but it works

it works best with sodium, because chunk loading is slow without it

while this doesn't have the most desirable effects (slow chunk loading without sodium), it is still infinitely better than something that doesn't work at all by leaking memory and crashing, so this should serve as a good temporary solution at the very least

note that this memory leak exists in vanilla, but is [fixed in sodium](https://github.com/CaffeineMC/sodium-fabric/blob/1.17.x/dev/src/main/java/me/jellysquid/mods/sodium/mixin/features/chunk_rendering/MixinChunkBuilder.java) (this pr basically applies the fix to the worldpreview code)